### PR TITLE
Make wireguard a bit less likely to have false positives

### DIFF
--- a/analyzer/protocol/wireguard/dpd.sig
+++ b/analyzer/protocol/wireguard/dpd.sig
@@ -2,6 +2,6 @@
 
 signature wireguard_packet {
   ip-proto == udp
-  payload /^(\x01|\x02|\x03|\x04)\x00\x00\x00/
+  payload /^(\x01|\x02|\x03)\x00\x00\x00/
   enable "spicy_Wireguard"
 }

--- a/analyzer/protocol/wireguard/wireguard.spicy
+++ b/analyzer/protocol/wireguard/wireguard.spicy
@@ -37,6 +37,7 @@ type HandshakeInitiation = unit {
 	encrypted_timestamp: bytes &size=AEAD_LEN(12);
 	mac1: bytes &size=16;
 	mac2: bytes &size=16;
+	nothing: bytes &eod &requires=(|$$| == 0);
 };
 
 type HandshakeResponse = unit {
@@ -46,12 +47,14 @@ type HandshakeResponse = unit {
 	encrypted_nothing: bytes &size=AEAD_LEN(0);
 	mac1: bytes &size=16;
 	mac2: bytes &size=16;
+	nothing: bytes &eod &requires=(|$$| == 0);
 };
 
 type PacketCookieReply = unit {
 	receiver_index: uint32;
 	nonce: bytes &size=24;
 	encrypted_cookie: bytes &size=AEAD_LEN(16);
+	nothing: bytes &eod &requires=(|$$| == 0);
 };
 
 type PacketData = unit {

--- a/analyzer/protocol/wireguard/wireguard.spicy
+++ b/analyzer/protocol/wireguard/wireguard.spicy
@@ -21,7 +21,7 @@ function AEAD_LEN(num: uint64) : uint64 {
 
 public type WireGuardPacket = unit {
 	message_type: uint8;
-	reserved_zero: bytes &size=3;
+	reserved_zero: bytes &size=3 &requires=($$ == b"\x00\x00\x00");
 	switch ( MessageType(self.message_type) ) {
 		MessageType::handshake_initiation -> handshake_initiation: HandshakeInitiation;
 		MessageType::handshake_response -> handshake_response: HandshakeResponse;


### PR DESCRIPTION
A few small changes to the protocol to check that we are not accidentally parsing other packets.

Might be enough to close #13 