### PR TITLE
Extend PNG test to catch Spicy's #817.

### DIFF
--- a/tests/file/png.zeek
+++ b/tests/file/png.zeek
@@ -3,6 +3,9 @@
 # @TEST-EXEC: btest-diff files.log
 # @TEST-EXEC: btest-diff png.log
 #
+# Spicy's #817 used to trigger a weird, make sure it doesn't come back.
+# @TEST-EXEC: test '!' -f weird.log
+#
 # @TEST-DOC: Test PNG analyzer with an image inside a small trace.
 
 @load spicy-analyzers/file/png


### PR DESCRIPTION
Note: turns out the file analyzer tests currently don't run because they aren't listed in the btest config. Wil fix that separately.