### PR TITLE
Disable JIT parallelism in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,7 @@
+environment:
+    # Enforce sequential JIT'ing of files for controlled memory usage.
+    HILTI_JIT_SEQUENTIAL: 1
+
 package_ci_task:
   timeout_in: 120m
   container:


### PR DESCRIPTION
This fix is related to zeek/spicy#828.