### PR TITLE
Wireguard: change logging to only have one line per connection

### DIFF
--- a/analyzer/protocol/wireguard/main.zeek
+++ b/analyzer/protocol/wireguard/main.zeek
@@ -43,8 +43,10 @@ export {
 	## Event raised for the wireguard packet_data packet
 	global wireguard::packet_data: event(c: connection, is_orig: bool, receiver_index: count, key_counter: count, encapsulated_packet_length: count);
 
+@ifdef ( Conn::register_removal_hook )
 	## Wireguard finalization hook; wireguard information is logged in it
 	global finalize_wireguard: Conn::RemovalHook;
+@endif
 }
 
 redef record connection += {
@@ -56,7 +58,9 @@ function set_session(c: connection)
 	if ( ! c?$wireguard )
 		{
 		c$wireguard = Info($uid=c$uid, $id=c$id);
+@ifdef ( Conn::register_removal_hook )
 		Conn::register_removal_hook(c, finalize_wireguard);
+@endif
 		}
 	}
 
@@ -80,7 +84,11 @@ event wireguard::handshake_response(c: connection, is_orig: bool, sender_index: 
 		c$wireguard$established = T;
 	}
 
+@ifdef ( Conn::register_removal_hook )
 hook finalize_wireguard(c: connection)
+@else
+event connection_state_remove(c: connection)
+@endif
 	{
 	Log::write(LOG, c$wireguard);
 	}

--- a/analyzer/protocol/wireguard/main.zeek
+++ b/analyzer/protocol/wireguard/main.zeek
@@ -5,28 +5,26 @@ module Wireguard;
 export {
 	redef enum Log::ID += { LOG };
 
-	type WireguardPacket: enum {
-		WG_HANDSHAKE_INITIATION,
-		WG_HANDSHAKE_RESPONSE,
-	};
-
 	## The record type which contains the fields of the Wireguard log.
 	## Wireguard purposefully contains only very limited information. As such, the only
 	## things that we record in the log are wireguard handshakes - since the frequency of handshakes
 	## (as well as the successes of them) might be of some interest
 	type Info: record {
-		### Time the packet was encountered
-		ts:             time            &log;
+		### Time the first packet was encountered
+		ts:             time            &log &default=network_time();
 		### Unique ID for the connection
 		uid:            string          &log;
 		## The connection's 4-tuple of endpoint addresses/ports
 		id:             conn_id         &log;
-		### The packet type
-		packet_type:    WireguardPacket &log;
-		### 32 bit identifier chosen by the sender
-		sender_index:   count           &log;
-		### 32 bit identifier chosen by the receiver
-		receiver_index: count           &log &optional;
+		### 32 bit identifier chosen by the sender. Not logged.
+		sender_index:   count           &optional;
+		### Set to true if we think that a handshake was succesfully performed.
+		### Please note that this flag is a bit speculative and should not be 100% relied on.
+		established:    bool            &log &default=F;
+		## Number of handshake initiation packets we have encountered during the connection
+		initiations:    count           &log &default=0;
+		## Number of handshake response packets we have encountered during the connection
+		responses:      count           &log &default=0;
 	};
 
 	## Event that can be handled to access the Wireguard
@@ -44,8 +42,23 @@ export {
 
 	## Event raised for the wireguard packet_data packet
 	global wireguard::packet_data: event(c: connection, is_orig: bool, receiver_index: count, key_counter: count, encapsulated_packet_length: count);
+
+	## Wireguard finalization hook; wireguard information is logged in it
+	global finalize_wireguard: Conn::RemovalHook;
 }
 
+redef record connection += {
+	wireguard: Info &optional;
+};
+
+function set_session(c: connection)
+	{
+	if ( ! c?$wireguard )
+		{
+		c$wireguard = Info($uid=c$uid, $id=c$id);
+		Conn::register_removal_hook(c, finalize_wireguard);
+		}
+	}
 
 event zeek_init() &priority=5
 	{
@@ -54,11 +67,20 @@ event zeek_init() &priority=5
 
 event wireguard::handshake_initiation(c: connection, is_orig: bool, sender_index: count, unencrypted_ephemeral: string, encrypted_static: string, encrypted_timestamp: string, mac1: string, mac2: string)
 	{
-	Log::write(Wireguard::LOG, Info($ts=network_time(), $uid=c$uid, $id=c$id, $packet_type=WG_HANDSHAKE_INITIATION, $sender_index=sender_index));
+	set_session(c);
+	c$wireguard$initiations += 1;
+	c$wireguard$sender_index = sender_index;
 	}
 
 event wireguard::handshake_response(c: connection, is_orig: bool, sender_index: count, receiver_index: count, unencrypted_ephemeral: string, encrypted_nothing: string, mac1: string, mac2: string)
 	{
-	Log::write(Wireguard::LOG, Info($ts=network_time(), $uid=c$uid, $id=c$id, $packet_type=WG_HANDSHAKE_RESPONSE, $sender_index=sender_index, $receiver_index=receiver_index));
+	set_session(c);
+	c$wireguard$responses += 1;
+	if ( c$wireguard?$sender_index && c$wireguard$sender_index == receiver_index )
+		c$wireguard$established = T;
 	}
 
+hook finalize_wireguard(c: connection)
+	{
+	Log::write(LOG, c$wireguard);
+	}

--- a/tests/Baseline/protocol.wireguard.wireguard/wireguard.log
+++ b/tests/Baseline/protocol.wireguard.wireguard/wireguard.log
@@ -6,8 +6,7 @@
 #unset_field	-
 #path	wireguard
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	packet_type	sender_index	receiver_index
-#types	time	string	addr	port	addr	port	enum	count	count
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	established	initiations	responses
+#types	time	string	addr	port	addr	port	bool	count	count
 #close XXXX-XX-XX-XX-XX-XX
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	188.166.170.114	45965	188.166.170.115	51194	Wireguard::WG_HANDSHAKE_INITIATION	3294832738	-
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	188.166.170.114	45965	188.166.170.115	51194	Wireguard::WG_HANDSHAKE_RESPONSE	182872200	3294832738
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	188.166.170.114	45965	188.166.170.115	51194	T	1	1


### PR DESCRIPTION
This commit revamps the wireguard logging. Now there is only one line
per connection that tracks connection establishment as well as the
number of handshake initiation and response packets.

Addresses GH-13