### PR TITLE
IPSec:  Fix various vector parsing issues.

### DIFF
--- a/analyzer/protocol/ipsec/ipsec.spicy
+++ b/analyzer/protocol/ipsec/ipsec.spicy
@@ -277,7 +277,7 @@ public type IPSecIKE = unit {
 	length: uint32;
 	payloads_v1: IPSecIKEv1_Payload(self.shared_info, self.message_id)[] &size=self.length-28 if (self.version.maj == 1 && !self.flags.E);
 	payloads_v2: IPSecIKEv2_Payload(self.shared_info, self.message_id)[] &size=self.length-28 if (self.version.maj == 2);
-} &requires=( (self.version.maj == 1 || self.version.maj == 2) && self.version.min == 0);
+} &requires=( (self.version.maj == 1 || self.version.maj == 2) && self.version.min == 0 );
 
 type IPSecIKEv2_Payload = unit(inout shared_info: SharedInfo, message_id: uint32) {
 	var message_id: uint32 = message_id;
@@ -318,7 +318,7 @@ type IPSecIKE_Payload_Header = unit {
 
 type IPSecIKEv2_SA_Payload = unit(message_id: uint32) {
 	var message_id: uint32 = message_id;
-	proposals: IPSecIKEv2_SA_Proposal(message_id)[];
+	proposals: IPSecIKEv2_SA_Proposal(message_id)[] &eod;
 };
 
 type IPSecIKEv2_SA_Proposal = unit(message_id: uint32) {
@@ -428,7 +428,7 @@ type IPSecIKEv2_D_Payload = unit(message_id: uint32) {
 	protocol_id: uint8 &convert=ProtocolID($$);
 	spi_size: uint8;
 	num_spi: uint16;
-	spis: spi(self.spi_size)[];
+	spis: spi(self.spi_size)[] &eod;
 };
 
 type spi = unit(spi_size: uint8) {
@@ -480,7 +480,7 @@ type IPSecIKEv2_CP_Payload = unit(message_id: uint32) {
 	var message_id: uint32 = message_id;
 	cfg_type: uint8 &convert=ConfigurationType($$);
 	reserved: bytes &size=3;
-	attributes: ConfigureAttribute(self.cfg_type, message_id)[];
+	attributes: ConfigureAttribute(self.cfg_type, message_id)[] &eod;
 };
 
 type ConfigureAttribute = unit(rec: ConfigurationType, message_id: uint32) {
@@ -488,11 +488,11 @@ type ConfigureAttribute = unit(rec: ConfigurationType, message_id: uint32) {
 	var cfg_type: ConfigurationType = rec;
 	attribute_type: bitfield(16) {
 		R: 15;
-		the_type: 0..14 &convert=CfgAttributeType($$);
+		the_type: 0..14;
 	};
 	length: uint16;
 	value: bytes &size=self.length;
-};
+} &requires=(self.attribute_type.R == 0);
 
 type IPSecIKEv2_EAP_Payload = unit(message_id: uint32) {
 	var message_id: uint32 = message_id;
@@ -557,7 +557,7 @@ type IPSecIKEv1_T_Payload = unit(message_id: uint32, header: IPSecIKE_Payload_He
 	transform_num: uint8;
 	transform_id: uint8;
 	reserved: bytes &size=2;
-	sa_attributes: DataAttribute(message_id, proposal_num, self.transform_id)[];
+	sa_attributes: DataAttribute(message_id, proposal_num, self.transform_id)[] &eod;
 };
 
 type IPSecIKEv1_KE_Payload = unit(message_id: uint32, header: IPSecIKE_Payload_Header) {
@@ -613,7 +613,7 @@ type IPSecIKEv1_D_Payload = unit(message_id: uint32, header: IPSecIKE_Payload_He
 	protocol_id: uint8 &convert=ProtocolID($$);
 	spi_size: uint8;
 	num_spi: uint16;
-	spis: spi(self.spi_size)[];
+	spis: spi(self.spi_size)[] &eod;
 };
 
 type IPSecIKEv1_VID_Payload = unit(message_id: uint32, header: IPSecIKE_Payload_Header) {

--- a/analyzer/protocol/ipsec/ipsec_zeek.spicy
+++ b/analyzer/protocol/ipsec/ipsec_zeek.spicy
@@ -384,7 +384,7 @@ public function create_configuration_attr_msg(msg: ipsec::ConfigureAttribute):
     return (
     	msg.message_id,
     	cast<uint8>(msg.cfg_type),
-    	cast<uint16>(msg.attribute_type.the_type),
+    	msg.attribute_type.the_type,
     	msg.length,
     	msg.value
     );


### PR DESCRIPTION
Fixing a parsing error where I didn't have &eod for some vectors.  Also remove enum from the_type since we don't know all cases yet but we still want to parse those payloads.  None of the tests change because I don't have a sanitized pcap with this scenario, yet.