### PR TITLE
Build package without any parallelism.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -3,9 +3,9 @@ depends = zeek/spicy-plugin *
 script_dir = analyzer
 plugin_dir = build/spicy-modules
 
-build_command = mkdir -p build && cd build && SPICYZ=%(package_base)s/spicy-plugin/build/plugin/bin/spicyz cmake .. && make -j 2
+build_command = mkdir -p build && cd build && SPICYZ=%(package_base)s/spicy-plugin/build/plugin/bin/spicyz cmake .. && make
 
 # If the package is already installed, the Spicy plugin would pull in both 
 # old and new *.hlto during testing. Hence we need to override the search path 
 # to point to only the new location.
-test_command = cd tests && SPICY_MODULE_PATH=$(pwd)/../build/spicy-modules btest -dj -a zkg
+test_command = cd tests && SPICY_MODULE_PATH=$(pwd)/../build/spicy-modules btest -d -a zkg


### PR DESCRIPTION
Since building this package is pretty memory intensive, do not assume
that we can build in parallel. Users can override this by setting
`MAKEFLAGS` in the environment, e.g., to build using all CPUs:

    $ MAKEFLAGS="-j$(nproc)" zkg install zeek/spicy-analyzers