### PR TITLE
Make parallel build and test opt-out instead of opt-in.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -3,9 +3,9 @@ depends = zeek/spicy-plugin *
 script_dir = analyzer
 plugin_dir = build/spicy-modules
 
-build_command = mkdir -p build && cd build && SPICYZ=%(package_base)s/spicy-plugin/build/plugin/bin/spicyz cmake .. && make
+build_command = mkdir -p build && cd build && SPICYZ=%(package_base)s/spicy-plugin/build/plugin/bin/spicyz cmake .. && make -j "${SPICY_ZKG_PROCESSES:-2}"
 
 # If the package is already installed, the Spicy plugin would pull in both 
 # old and new *.hlto during testing. Hence we need to override the search path 
 # to point to only the new location.
-test_command = cd tests && SPICY_MODULE_PATH=$(pwd)/../build/spicy-modules btest -d -a zkg
+test_command = cd tests && SPICY_MODULE_PATH=$(pwd)/../build/spicy-modules btest -d -j "${SPICY_ZKG_PROCESSES:-2}" -a zkg


### PR DESCRIPTION
In b06e4bf741f we made the package build and test process sequential to
not overwhelm machines with too little RAM. This had the side effect of
making _all builds_ slower.

In this patch we revise that fix but going back to package build and
test parallel by default, but with an option to opt out of this. If the
environment variable `SPICY_ZKG_PROCESSES` is set, we will use that as
the number of build or test jobs to spawn; otherwise we default to a
hardcoded level of parallelism.