### PR TITLE
Ldap over UDP and redact clear text passwords from logs

### DIFF
--- a/analyzer/ldap/ldap.evt
+++ b/analyzer/ldap/ldap.evt
@@ -4,7 +4,9 @@ protocol analyzer spicy::LDAP_TCP over TCP:
     parse with LDAP::Messages,
     ports { 389/tcp, 3268/tcp};
 
-# TODO: LDAP can also use UDP transport
+protocol analyzer spicy::LDAP_UDP over UDP:
+    parse with LDAP::Messages,
+    ports { 389/udp };
 
 import LDAP;
 import LDAP_Zeek;

--- a/analyzer/ldap/main.zeek
+++ b/analyzer/ldap/main.zeek
@@ -6,6 +6,9 @@ export {
   redef enum Log::ID += { LDAP_LOG,
                           LDAP_SEARCH_LOG };
 
+	## Whether clear text passwords are captured or not.
+	option default_capture_password = F;
+
   #############################################################################
   # This is the format of ldap.log (ldap operations minus search-related)
   # Each line represents a unique connection+message_id (requests/responses)
@@ -340,7 +343,10 @@ event LDAP::message(c: connection,
     if ( argument != "" ) {
       if ( ! c$ldap_messages[message_id]?$argument )
         c$ldap_messages[message_id]$argument = vector();
-      c$ldap_messages[message_id]$argument += argument;
+      if ("bind simple" in c$ldap_messages[message_id]$opcode && !default_capture_password)
+        c$ldap_messages[message_id]$argument += "REDACTED";
+      else
+        c$ldap_messages[message_id]$argument += argument;
     }
 
     if (opcode in OPCODES_FINISHED) {

--- a/tests/Baseline/protocol.ldap.basic/ldap.log
+++ b/tests/Baseline/protocol.ldap.basic/ldap.log
@@ -9,5 +9,5 @@
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	message_id	version	opcode	result	diagnostic_message	object	argument
 #types	time	string	addr	port	addr	port	string	int	int	set[string]	set[string]	vector[string]	vector[string]	vector[string]
 #close XXXX-XX-XX-XX-XX-XX
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	10.0.0.1	25936	10.0.0.2	3268	tcp	1	3	bind simple	success	-	xxxxxxxxxxx@xx.xxx.xxxxx.net	passwor8d1
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	10.0.0.1	25936	10.0.0.2	3268	tcp	3	3	bind simple	success	-	CN=xxxxxxxx\x2cOU=Users\x2cOU=Accounts\x2cDC=xx\x2cDC=xxx\x2cDC=xxxxx\x2cDC=net	<...>/c0t0d0s0
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	10.0.0.1	25936	10.0.0.2	3268	tcp	1	3	bind simple	success	-	xxxxxxxxxxx@xx.xxx.xxxxx.net	REDACTED
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	10.0.0.1	25936	10.0.0.2	3268	tcp	3	3	bind simple	success	-	CN=xxxxxxxx\x2cOU=Users\x2cOU=Accounts\x2cDC=xx\x2cDC=xxx\x2cDC=xxxxx\x2cDC=net	REDACTED


### PR DESCRIPTION
LDAP simple binds had their clear text passwords logged by default.  I changed the behavior so someone had to turn it on like the other native Zeek analyzers (FTP, SOCK, HTTP, etc).  

I also enabled LDAP over UDP.  It seems to be working on networks I monitor.  I could add tests, but this was the only decent pcap I found and didn't want to run into attribution issues putting the pcap here:  https://www.cloudshark.org/captures/1e1bfb6a3b44?filter=frame%20and%20frame%20and%20eth%20and%20ip%20and%20udp%20and%20cldap