### PR TITLE
Pin zeek-spicy-openvpn==0.1.0.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Show logs
         if: always()
         run: |
-          tail -n 1000000 $(zkg config state_dir)/logs/*.log
+          tail -n 1000000 $(zkg config state_dir)/logs/*.log $(zkg config state_dir)/testing/*/clones/*/zkg.*.stderr

--- a/zkg.meta
+++ b/zkg.meta
@@ -15,6 +15,6 @@ depends = http://github.com/zeek/spicy-dhcp >=0.0.1
     http://github.com/zeek/spicy-zip >=0.0.1
     http://github.com/corelight/zeek-spicy-facefish >=0.1.0
     http://github.com/corelight/zeek-spicy-ipsec >=0.2.1
-    http://github.com/corelight/zeek-spicy-openvpn >=0.1.0
+    http://github.com/corelight/zeek-spicy-openvpn ==0.1.0
     http://github.com/corelight/zeek-spicy-stun >=0.2.1
     http://github.com/corelight/zeek-spicy-wireguard >=0.1.0


### PR DESCRIPTION
Up until v0.1.3 that package does not pass its tests so cannot be
installed via zkg, see
https://github.com/corelight/zeek-spicy-openvpn/issues/3.

Pinning it for now to avoid breaking users.