### PR TITLE
Unpin zeek-spicy-openvpn.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -15,6 +15,6 @@ depends = http://github.com/zeek/spicy-dhcp >=0.0.1
     http://github.com/zeek/spicy-zip >=0.0.1
     http://github.com/corelight/zeek-spicy-facefish >=0.1.0
     http://github.com/corelight/zeek-spicy-ipsec >=0.2.1
-    http://github.com/corelight/zeek-spicy-openvpn ==0.1.0
+    http://github.com/corelight/zeek-spicy-openvpn >=0.1.3
     http://github.com/corelight/zeek-spicy-stun >=0.2.1
     http://github.com/corelight/zeek-spicy-wireguard >=0.1.0


### PR DESCRIPTION
Now that zeek/spicy-plugin#92 has been fixed the package should work
again.