### PR TITLE
Exclude corelight/zeek-spicy-ipsec.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -14,7 +14,8 @@ depends = http://github.com/zeek/spicy-dhcp >=0.0.1
     http://github.com/zeek/spicy-tftp >=0.0.1
     http://github.com/zeek/spicy-zip >=0.0.1
     http://github.com/corelight/zeek-spicy-facefish >=0.1.0
-    http://github.com/corelight/zeek-spicy-ipsec >=0.2.1
+    # TODO(bbannier): Include this package again once https://github.com/corelight/zeek-spicy-ipsec/issues/4 is fixed.
+    # http://github.com/corelight/zeek-spicy-ipsec >=0.2.1
     http://github.com/corelight/zeek-spicy-openvpn ==0.1.0
     http://github.com/corelight/zeek-spicy-stun >=0.2.1
     http://github.com/corelight/zeek-spicy-wireguard >=0.1.0


### PR DESCRIPTION
That package can not be installed currently in zeek-4.2 environments due
to https://github.com/corelight/zeek-spicy-ipsec/issues/4.