### PR TITLE
Move CI to upstream Zeek images.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,38 +8,31 @@ on:
 jobs:
   Check:
     runs-on: ubuntu-latest
-    container: zeekurity/spicy
+    strategy:
+      matrix:
+        container:
+        - zeekurity/zeek
+        - zeekurity/zeek-dev
+    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Prepare
-        env:
-          PATH: /usr/local/bin:/opt/cmake/bin:/opt/spicy/bin:/opt/zeek/bin:/opt/zeek/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - name: Install build dependencies
         run: |
-          # Clean out leftover logs for to make it easier to print "our" logs.
-          zkg autoconfig
-
-          rm -f $(zkg config state_dir)/logs/*.log
-          zkg -vvvvv purge --force
-
-          # Manually install spicy-plugin until the image contains a zkg version with a fix for https://github.com/zeek/package-manager/issues/106 (>=zkg-2.12.0).
-          zkg -vvvvv install --force --skiptests spicy-plugin
+          apt-get update
+          apt-get install -y cmake g++ libpcap-dev
 
       - name: Install
-        env:
-          PATH: /usr/local/bin:/opt/cmake/bin:/opt/spicy/bin:/opt/zeek/bin:/opt/zeek/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         run: |
           git clean -fd
           eval $(zkg env)
           echo Y | zkg -vvvvv install .
 
       - name: Check install
-        env:
-          PATH: /usr/local/bin:/opt/cmake/bin:/opt/spicy/bin:/opt/zeek/bin:/opt/zeek/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         run: |
           zeek -NN local
 
       - name: Show logs
         if: always()
         run: |
-          tail -n 1000000 $(zkg config state_dir)/logs/*.log $(zkg config state_dir)/testing/*/clones/*/zkg.*.stderr
+          tail -n 1000000 $(zkg config state_dir)/logs/*.log $(zkg config state_dir)/testing/*/clones/*/zkg.*.stderr || true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install
         run: |
+          git config --global --add safe.directory $PWD
           git clean -fd
           eval $(zkg env)
           echo Y | zkg -vvvvv install .


### PR DESCRIPTION
We also extend the test matrix to test both against the latest release and the current development snapshot.