### PR TITLE
Drop spicy-ldap from dependencies.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -8,7 +8,6 @@ description = Meta package for a number of Spicy-based analyzers.
 depends = http://github.com/zeek/spicy-dhcp >=0.0.1
     http://github.com/zeek/spicy-dns >=0.0.2
     http://github.com/zeek/spicy-http >=0.0.1
-    http://github.com/zeek/spicy-ldap >=0.0.2
     http://github.com/zeek/spicy-pe >=0.0.3
     http://github.com/zeek/spicy-png >=0.0.2
     http://github.com/zeek/spicy-tftp >=0.0.1


### PR DESCRIPTION
As of zeek-6.1 spicy-ldap is part of Zeek. Drop if from the list of dependencies. Users who still want to install this package should install it explicitly.